### PR TITLE
Update BigDecimal.php

### DIFF
--- a/lstgen/generators/php/BigDecimal.php
+++ b/lstgen/generators/php/BigDecimal.php
@@ -32,7 +32,7 @@ class BigDecimal {
     }
 
     public function setScale($scale, $rounding) {
-        return new BigDecimal($this->bd->withScale($scale, $rounding));
+        return new BigDecimal($this->bd->toScale($scale, $rounding));
     }
 
     public function add($other) {


### PR DESCRIPTION
withScale was deprecated and removed with Version 0.6.0 of Brick\Math, use toScale instead